### PR TITLE
Fix add JsonRPC header to Ethereum EL requests

### DIFF
--- a/plugin/ethereum_el/ethereum_el_test.go
+++ b/plugin/ethereum_el/ethereum_el_test.go
@@ -31,6 +31,11 @@ func TestEthereumEL(t *testing.T) {
 		if err := json.Unmarshal(data, &req); err != nil {
 			return
 		}
+		if req.JsonRPC != "2.0" {
+			w.Write([]byte(`invalid request`))
+			return
+		}
+
 		resp, ok := cb[req.Method]
 		if ok {
 			w.Write([]byte(resp))


### PR DESCRIPTION
This PR fixes a bug on the `Ethereum EL` plugin where the `JsonRPC` field was not set.